### PR TITLE
Add RegisterPersonSettings configuration for configure the preregister code lifetime

### DIFF
--- a/Helper/RegisterPersonSettings.cs
+++ b/Helper/RegisterPersonSettings.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace AuthApi.Helper
+{
+    public class RegisterPersonSettings
+    {
+        public long TokenLifeTimeSeconds { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -39,7 +39,8 @@ builder.Services.AddCors(options =>
 
 // Add services to the container.
 builder.Services.Configure<JwtSettings>( builder.Configuration.GetSection("JwtSettings"));
-builder.Services.Configure<ResetPasswordSettings>( builder.Configuration.GetSection("ResetPasswordSettings"));
+builder.Services.Configure<ResetPasswordSettings>(builder.Configuration.GetSection("ResetPasswordSettings"));
+builder.Services.Configure<RegisterPersonSettings>(builder.Configuration.GetSection("RegisterPersonSettings"));
 builder.Services.Configure<EmailSettings>( builder.Configuration.GetSection("EmailSettings"));
 builder.Services.Configure<WelcomeEmailSources>( builder.Configuration.GetSection("WelcomeEmailSources"));
 builder.Services.Configure<MinioSettings>( builder.Configuration.GetSection("MinioSettings"));

--- a/Services/PreregisterService.cs
+++ b/Services/PreregisterService.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Options;
 
 namespace AuthApi.Services
 {
-    public class PreregisterService( DirectoryDBContext dbContext, ICryptographyService cryptographyService, ILogger<PreregisterService> logger, PersonService personService, IEmailProvider emailProvider, IOptions<WelcomeEmailSources> WelcomeEmailSourcesOptions, IOptions<ResetPasswordSettings> resetPasswordOptions)
+    public class PreregisterService(DirectoryDBContext dbContext, ICryptographyService cryptographyService, ILogger<PreregisterService> logger, PersonService personService, IEmailProvider emailProvider, IOptions<WelcomeEmailSources> WelcomeEmailSourcesOptions, IOptions<RegisterPersonSettings> registerPersonOptions)
     {
         private readonly DirectoryDBContext dbContext = dbContext;
         private readonly ICryptographyService cryptographyService = cryptographyService;
@@ -22,7 +22,7 @@ namespace AuthApi.Services
         private readonly PersonService personService = personService;
         private readonly IEmailProvider emailProvider = emailProvider;
         private readonly WelcomeEmailSources welcomeEmailSources = WelcomeEmailSourcesOptions.Value;
-        private readonly ResetPasswordSettings resetPasswordSettings = resetPasswordOptions.Value;
+        private readonly RegisterPersonSettings registerPersonSettings = registerPersonOptions.Value;
         
         /// <summary>
         ///  Create a new preregister record
@@ -46,7 +46,7 @@ namespace AuthApi.Services
 
             // * prepare the validation code and the lifetime
             string validationCode = PreregisterToken.GenerateCode();
-            var lifeTime = TimeSpan.FromSeconds(resetPasswordSettings.TokenLifeTimeSeconds);
+            var lifeTime = TimeSpan.FromSeconds(registerPersonSettings.TokenLifeTimeSeconds);
             var codeLifeTime = DateTime.Now.Add(lifeTime);
 
 

--- a/appsettings.sample.json
+++ b/appsettings.sample.json
@@ -19,6 +19,9 @@
     "TokenLifeTimeSeconds": 3600,
     "DestinationUrl": ""
   },
+  "RegisterPersonSettings":{
+    "TokenLifeTimeSeconds": 57600
+  },
   "EmailSettings":{
     "ApiUri": "",
     "From": "",


### PR DESCRIPTION
close #134

Se agrego un nuevo apartada en el archivo de configuracion `appsettings.json` para especificar el tiempo de vida del codigo de preregistro, por default es 57600 segundos (6hrs)